### PR TITLE
V0.28

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ test:
     - pip
   commands:
     - pip check
-    - versioneer version
+    - {{ SP_DIR }}/versioneer version
 
 about:
   home: https://github.com/python-versioneer/python-versioneer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  noarch: python
+  skip: true  # [py<37]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
@@ -21,13 +21,16 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
     - setuptools
-    - tomli
+    - wheel
+    - tomli 2.0.1
   run:
-    - python >=3.7
+    - python
 
 test:
+  imports:
+    - marshmallow
   requires:
     - pip
   commands:
@@ -38,7 +41,13 @@ about:
   home: https://github.com/python-versioneer/python-versioneer
   license: Unlicense
   license_file: LICENSE
+  license_family: None
   summary: Easy VCS-based management of project version strings
+  description: |
+    A lightweight library for converting complex
+    datatypes to and from native Python datatypes.
+  dev_url: https://marshmallow.readthedocs.io/
+  doc_url: https://marshmallow.readthedocs.io/en/stable/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,8 +46,8 @@ about:
   description: |
     This is a tool for managing a recorded version number
     in setuptools-based python projects.
-  dev_url: https://marshmallow.readthedocs.io/
-  doc_url: https://marshmallow.readthedocs.io/en/stable/
+  dev_url: https://github.com/python-versioneer/python-versioneer/blob/master/pyproject.toml
+  doc_url: https://github.com/python-versioneer/python-versioneer/blob/master/pyproject.toml
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,8 +44,8 @@ about:
   license_family: None
   summary: Easy VCS-based management of project version strings
   description: |
-    A lightweight library for converting complex
-    datatypes to and from native Python datatypes.
+    This is a tool for managing a recorded version number
+    in setuptools-based python projects.
   dev_url: https://marshmallow.readthedocs.io/
   doc_url: https://marshmallow.readthedocs.io/en/stable/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
 
 test:
   imports:
-    - marshmallow
+    - versioneer
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ test:
     - pip
   commands:
     - pip check
-    - {{ SP_DIR }}/versioneer version
+    - versioneer version
 
 about:
   home: https://github.com/python-versioneer/python-versioneer

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - python
     - setuptools
     - wheel
-    - tomli 2.0.1
+    - tomli 2.0.1  # [py<311]
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,8 +29,6 @@ requirements:
     - python
 
 test:
-  imports:
-    - versioneer
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,8 @@ requirements:
     - python
 
 test:
+  imports:
+    - versioneer
   requires:
     - pip
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   skip: true  # [py<37]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - versioneer = versioneer:main
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 build:
   skip: true  # [py<37]
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - versioneer = versioneer:main
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,9 @@ test:
     - pip
   commands:
     - pip check
-    - versioneer version
+    # CI is picking up versioneer from builder environment
+    # commenting out this test until ticket SIR-588 is resolved.
+    - versioneer version  # [not osx]
 
 about:
   home: https://github.com/python-versioneer/python-versioneer


### PR DESCRIPTION
[Upstream](https://github.com/python-versioneer/python-versioneer)
[Changelog](https://github.com/python-versioneer/python-versioneer/releases)

### Actions
- Removed noarch
- Dependency updates
- Linter fixes

### Notes
- CI is picking up versioneer from builder environment. Commenting out this test until ticket [SIR-588](https://anaconda.atlassian.net/browse/SIR-588) is resolved.
- This is a new dependency for Dask

[SIR-588]: https://anaconda.atlassian.net/browse/SIR-588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ