### PR TITLE
Rebuild against python 3.14

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true  # [py<37]
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - versioneer = versioneer:main


### PR DESCRIPTION
versioneer 0.29

**Destination channel:** defaults

### Links

- [PKG-10370](https://anaconda.atlassian.net/browse/PKG-10370) 
- [Upstream repository](https://github.com/python-versioneer/python-versioneer)

### Explanation of changes:

- rebuild against python 3.14. This package is required by pandas


[PKG-10370]: https://anaconda.atlassian.net/browse/PKG-10370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ